### PR TITLE
feat(pencil): upgraded to BDK 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.finos.symphony.bdk</groupId>
                 <artifactId>symphony-bdk-bom</artifactId>
-                <version>2.14.3</version>
+                <version>3.0.0-RC4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.finos.symphony.bdk</groupId>
             <artifactId>symphony-bdk-test-spring-boot</artifactId>
-            <version>2.14.3</version>
+            <version>3.0.0-RC4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -87,7 +87,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.7.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -107,7 +106,8 @@
                 <version>0.8.11</version>
                 <configuration>
                     <excludes>
-                        <exclude>**/model/*</exclude>
+                        <exclude>com/symphony/devrel/pollbot/model/**</exclude>
+                        <exclude>com/symphony/devrel/pollbot/PollBot.class</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
BREAKING CHANGE: Java 17 is now required as part of Spring Boot 3 which BDK 3.0 uses